### PR TITLE
Fix loading galaxy routes

### DIFF
--- a/SpanshRouter/SpanshRouter.py
+++ b/SpanshRouter/SpanshRouter.py
@@ -321,7 +321,11 @@ class SpanshRouter():
             self.jumps_left = 0
             for row in self.route[self.offset:]:
                 if row[1] not in [None, "", []]:
+                if not self.galaxy: # galaxy type doesn't have a jumps column
                     self.jumps_left += int(row[1])
+                else:
+                    self.jumps_left += 1
+                    
 
             self.next_stop = self.route[self.offset][0]
             self.update_bodies_text()


### PR DESCRIPTION
Galaxy routes have no jumps column. This is handled everywhere except in loading a saved plot, which I added.