### PR TITLE
Fix installation instructions to point to this fork instead of outdated releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ You need to grant additional permissions and set an environment variable. You ca
 **Option A - Using Flatseal (recommended for most users):**
 1. Install Flatseal from your software center if not already installed
 2. Open Flatseal and select "EDMarketConnector" from the list
-3. Under "Socket" enable "Wayland windowing system (`socket=wayland`)"
-4. Scroll down to "Filesystem" and enable "All system libraries, executables and static data (`filesystem=host-os`)"
+3. Under "Socket" enable "Wayland windowing system" (`socket=wayland`)
+4. Scroll down to "Filesystem" and enable "All system libraries, executables and static data" (`filesystem=host-os`)
 5. Scroll to "Environment" and add the following variable:
    - `EDMC_SPANSH_ROUTER_XCLIP=/run/host/usr/bin/wl-copy`
 6. Restart EDMC


### PR DESCRIPTION
Hey!
Fixed the installation instructions that were pointing to outdated releases from the original repository. The old release files (from 2020) don't work with modern EDMC versions and cause the plugin UI to not appear.
   
   Changes made:
   - Updated download instructions to use this fork's code instead of old releases
   - Added warning about not using old releases
   - Improved Flatpak/Wayland setup instructions with both CLI and Flatseal (GUI) options
   - Fixed typo in xclip installation command
   - Clarified that auto-updates don't work in this fork
   
   I encountered this issue myself - the old files prevented SpanshRouter from showing any UI elements in EDMC.
   
   Thank you for maintaining the plugin for EDMC Commander! o7