### PR TITLE
Fix: Keyboard input loss on Wayland after clipboard copy

### DIFF
--- a/SpanshRouter/SpanshRouter.py
+++ b/SpanshRouter/SpanshRouter.py
@@ -375,11 +375,15 @@ class SpanshRouter():
             logger.warning(''.join('!! ' + line for line in lines))
 
     def copy_waypoint(self):
-        if sys.platform == "linux" or sys.platform == "linux2":
+        if sys.platform in ("linux", "linux2"):
             clipboard_cli = os.getenv("EDMC_SPANSH_ROUTER_XCLIP") or "xclip -selection c"
             clipboard_cli = clipboard_cli.split()
-            command = subprocess.Popen(["echo", "-n", self.next_stop], stdout=subprocess.PIPE)
-            subprocess.Popen(clipboard_cli, stdin=command.stdout)
+            subprocess.run(
+                clipboard_cli,
+                input=self.next_stop.encode(),
+                timeout=5,
+                check=False,
+            )
         else:
             self.parent.clipboard_clear()
             self.parent.clipboard_append(self.next_stop)


### PR DESCRIPTION
in `SpanshRouter.py` lines 376–389

used a double `subprocess.Popen` pattern (`echo | wl-copy`)
where neither process was waited on and the pipe between them was never closed.

Replaced the double `Popen` pipe with a single `subprocess.run(input=...)`

This fix is fully compatible with both xclip and wl-copy.
